### PR TITLE
Update extension + deprecated hook

### DIFF
--- a/CRM/Contact/Form/APIKey.php
+++ b/CRM/Contact/Form/APIKey.php
@@ -32,7 +32,7 @@ class CRM_Contact_Form_APIKey extends CRM_Core_Form {
 
     function buildQuickForm() {
         $this->applyFilter('__ALL__', 'trim');
-        $this->add('text', 'api_key', ts('API Key'), array('size' => "32", 'maxlength' => "32"));
+        $this->add('text', 'api_key', ts('Api Key'), array('size' => "32", 'maxlength' => "32"));
 
         $buttons = array(
             array(

--- a/CRM/Contact/Page/View/APIKey.php
+++ b/CRM/Contact/Page/View/APIKey.php
@@ -59,7 +59,7 @@ class CRM_Contact_Page_View_APIKey extends CRM_Core_Page {
      * @access public
      */
     function edit() {
-        $controller = new CRM_Core_Controller_Simple('CRM_Contact_Form_APIKey', ts('API Key'), $this->_action);
+        $controller = new CRM_Core_Controller_Simple('CRM_Contact_Form_APIKey', ts('Api Key'), $this->_action);
         $controller->setEmbedded(TRUE);
 
         // set the userContext stack

--- a/apikey.civix.php
+++ b/apikey.civix.php
@@ -3,32 +3,116 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
- * (Delegated) Implementation of hook_civicrm_config
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Apikey_ExtensionUtil {
+  const SHORT_NAME = "apikey";
+  const LONG_NAME = "com.cividesk.apikey";
+  const CLASS_PREFIX = "CRM_Apikey";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Apikey_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _apikey_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
-  if ($configured) return;
+  if ($configured) {
+    return;
+  }
   $configured = TRUE;
 
   $template =& CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
-  if ( is_array( $template->template_dir ) ) {
-      array_unshift( $template->template_dir, $extDir );
-  } else {
-      $template->template_dir = array( $extDir, $template->template_dir );
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
+  }
+  else {
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path( );
-  set_include_path( $include_path );
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_xmlMenu
+ * (Delegated) Implements hook_civicrm_xmlMenu().
  *
  * @param $files array(string)
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
 function _apikey_civix_civicrm_xmlMenu(&$files) {
   foreach (_apikey_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -37,57 +121,83 @@ function _apikey_civix_civicrm_xmlMenu(&$files) {
 }
 
 /**
- * Implementation of hook_civicrm_install
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _apikey_civix_civicrm_install() {
   _apikey_civix_civicrm_config();
   if ($upgrader = _apikey_civix_upgrader()) {
-    return $upgrader->onInstall();
+    $upgrader->onInstall();
   }
 }
 
 /**
- * Implementation of hook_civicrm_uninstall
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function _apikey_civix_civicrm_postInstall() {
+  _apikey_civix_civicrm_config();
+  if ($upgrader = _apikey_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
+      $upgrader->onPostInstall();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _apikey_civix_civicrm_uninstall() {
   _apikey_civix_civicrm_config();
   if ($upgrader = _apikey_civix_upgrader()) {
-    return $upgrader->onUninstall();
+    $upgrader->onUninstall();
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_enable
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _apikey_civix_civicrm_enable() {
   _apikey_civix_civicrm_config();
   if ($upgrader = _apikey_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
-      return $upgrader->onEnable();
+    if (is_callable([$upgrader, 'onEnable'])) {
+      $upgrader->onEnable();
     }
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_disable
+ * (Delegated) Implements hook_civicrm_disable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ * @return mixed
  */
 function _apikey_civix_civicrm_disable() {
   _apikey_civix_civicrm_config();
   if ($upgrader = _apikey_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
-      return $upgrader->onDisable();
+    if (is_callable([$upgrader, 'onDisable'])) {
+      $upgrader->onDisable();
     }
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_upgrade
+ * (Delegated) Implements hook_civicrm_upgrade().
  *
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _apikey_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _apikey_civix_upgrader()) {
@@ -95,24 +205,36 @@ function _apikey_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   }
 }
 
+/**
+ * @return CRM_Apikey_Upgrader
+ */
 function _apikey_civix_upgrader() {
-  if (!file_exists(__DIR__.'/CRM/Apikey/Upgrader.php')) {
+  if (!file_exists(__DIR__ . '/CRM/Apikey/Upgrader.php')) {
     return NULL;
-  } else {
+  }
+  else {
     return CRM_Apikey_Upgrader_Base::instance();
   }
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Search directory tree for files which match a glob pattern.
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
+ * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ *
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
  */
 function _apikey_civix_find_files($dir, $pattern) {
-  $todos = array($dir);
-  $result = array();
+  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
+    return CRM_Utils_File::findFiles($dir, $pattern);
+  }
+
+  $todos = [$dir];
+  $result = [];
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_apikey_civix_glob("$subdir/$pattern") as $match) {
@@ -123,8 +245,9 @@ function _apikey_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry == '.' || $entry == '..') {
-        } elseif (is_dir($path)) {
+        if ($entry[0] == '.') {
+        }
+        elseif (is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -133,21 +256,100 @@ function _apikey_civix_find_files($dir, $pattern) {
   }
   return $result;
 }
+
 /**
- * (Delegated) Implementation of hook_civicrm_managed
+ * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _apikey_civix_civicrm_managed(&$entities) {
   $mgdFiles = _apikey_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'com.cividesk.apikey';
+        $e['module'] = E::LONG_NAME;
+      }
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
       }
       $entities[] = $e;
     }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_caseTypes().
+ *
+ * Find any and return any files matching "xml/case/*.xml"
+ *
+ * Note: This hook only runs in CiviCRM 4.4+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
+ */
+function _apikey_civix_civicrm_caseTypes(&$caseTypes) {
+  if (!is_dir(__DIR__ . '/xml/case')) {
+    return;
+  }
+
+  foreach (_apikey_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+    $name = preg_replace('/\.xml$/', '', basename($file));
+    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
+      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
+      throw new CRM_Core_Exception($errorMessage);
+    }
+    $caseTypes[$name] = [
+      'module' => E::LONG_NAME,
+      'name' => $name,
+      'file' => $file,
+    ];
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
+ *
+ * Note: This hook only runs in CiviCRM 4.5+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+ */
+function _apikey_civix_civicrm_angularModules(&$angularModules) {
+  if (!is_dir(__DIR__ . '/ang')) {
+    return;
+  }
+
+  $files = _apikey_civix_glob(__DIR__ . '/ang/*.ang.php');
+  foreach ($files as $file) {
+    $name = preg_replace(':\.ang\.php$:', '', basename($file));
+    $module = include $file;
+    if (empty($module['ext'])) {
+      $module['ext'] = E::LONG_NAME;
+    }
+    $angularModules[$name] = $module;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _apikey_civix_civicrm_themes(&$themes) {
+  $files = _apikey_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
   }
 }
 
@@ -159,50 +361,117 @@ function _apikey_civix_civicrm_managed(&$entities) {
  * result for an empty match is sometimes array() and sometimes FALSE.
  * This wrapper provides consistency.
  *
- * @see http://php.net/glob
+ * @link http://php.net/glob
  * @param string $pattern
- * @return array, possibly empty
+ *
+ * @return array
  */
 function _apikey_civix_glob($pattern) {
   $result = glob($pattern);
-  return is_array($result) ? $result : array();
+  return is_array($result) ? $result : [];
 }
 
 /**
- * Inserts a navigation menu item at a given place in the hierarchy
+ * Inserts a navigation menu item at a given place in the hierarchy.
  *
- * $menu - menu hierarchy
- * $path - path where insertion should happen (ie. Administer/System Settings)
- * $item - menu you need to insert (parent/child attributes will be filled for you)
- * $parentId - used internally to recurse in the menu structure
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
  */
-function _apikey_civix_insert_navigationMenu(&$menu, $path, $item, $parentId = null) {
-  static $navId;
-
+function _apikey_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    if (!$navId) $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
-    $navId ++;
-    $menu[$navId] = array (
-      'attributes' => array_merge($item, array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-        'parentID'   => $parentId,
-        'navID'      => $navId,
-      ))
-    );
-    return true;
-  } else {
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
     // Find an recurse into the next level down
-    $found = false;
+    $found = FALSE;
     $path = explode('/', $path);
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
-        if (!$entry['child']) $entry['child'] = array();
-        $found = _apikey_civix_insert_navigationMenu($entry['child'], implode('/', $path), $item, $key);
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _apikey_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _apikey_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _apikey_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _apikey_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _apikey_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _apikey_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _apikey_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_alterSettingsFolders().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
+ */
+function _apikey_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+    $metaDataFolders[] = $settingsDir;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function _apikey_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, []);
 }

--- a/apikey.php
+++ b/apikey.php
@@ -88,20 +88,25 @@ function apikey_civicrm_managed(&$entities) {
 }
 
 /**
- * Implementation of hook_civicrm_tabs
+ * Implements hook_civicrm_tabset().
  */
-function apikey_civicrm_tabs( &$tabs, $contactID ) {
-  $session = CRM_Core_Session::singleton();
+function apikey_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view' && !empty($context['contact_id'])) {
+    $contactID = $context['contact_id'];
+    $is_admin = CRM_Core_Permission::check(['administer CiviCRM', 'edit all contacts']);
+    $is_myself = ($contactID == CRM_Core_Session::getLoggedInContactID());
 
-  $is_admin = CRM_Core_Permission::check('administer CiviCRM') && CRM_Core_Permission::check('edit all contacts');
-  $is_myself = ($contactID && ($contactID == $session->get('userID')));
-  if ($is_admin || $is_myself) {
-    $url = CRM_Utils_System::url( 'civicrm/contact/view/apikey', "reset=1&cid={$contactID}&snippet=1" );
-    $tabs[] = array(
-      'id' => 'apiKey',
-      'url' => $url,
-      'title' => 'API Key',
-      'weight' => 300,
-    );
+    if ($is_admin || $is_myself) {
+      $url = CRM_Utils_System::url('civicrm/contact/view/apikey', "reset=1&cid={$contactID}&snippet=1");
+      $tabs[] = [
+        'id' => 'apiKey',
+        'url' => $url,
+        'title' => ts('Api Key'),
+        'weight' => 300,
+        'icon' => 'crm-i fa-key',
+        'count' => CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'api_key') ? 1 : 0,
+      ];
+    }
   }
+
 }

--- a/info.xml
+++ b/info.xml
@@ -17,7 +17,9 @@
   <version>1.2</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.2</ver><ver>4.3</ver><ver>4.4</ver><ver>4.5</ver><ver>4.6</ver><ver>4.7</ver>
+    <ver>4.6</ver>
+    <ver>4.7</ver>
+    <ver>5.0</ver>
   </compatibility>
   <downloadUrl>https://github.com/cividesk/com.cividesk.apikey/archive/v1.2.zip</downloadUrl>
   <comments>Once installed, an 'API Key' tab will be available on contact screens for which you are authorized to manage the key. You are authorized either if the contact if yourself, or if you are an administrator with the 'edit all contacts' permission.</comments>

--- a/templates/CRM/Contact/Page/View/APIKey.tpl
+++ b/templates/CRM/Contact/Page/View/APIKey.tpl
@@ -1,25 +1,25 @@
 {* this template is used to display the 'API Key' tab for a contact *}
 
 <div class="form-item">
-    <fieldset><legend>{ts}API Key{/ts}</legend>
+    <fieldset><legend>{ts}Api Key{/ts}</legend>
         <div class="crm-block crm-form-block crm-cividesk-apikey-form-block">
-            
+
             {if $isAdmin || $isMyself}
 
             {if $apiKey}
-            <div class="label" style="float:left">Your API key is:&nbsp;</div>
+            <div class="label" style="float:left">{ts}Api Key{/ts}:&nbsp;</div>
             <div style="float:left"><strong>{$apiKey}</strong></div><br />
             <br />
             {/if}
 
             <div class="action-link">
-                <a class="button" href="{$addApiKeyUrl}" accesskey="N"><span><div class="icon add-icon"></div>{if $apiKey}Edit{else}Add{/if} API Key</span></a>
+                <a class="button" href="{$addApiKeyUrl}" ><span><i class="crm-i fa-plus"></i> {if $apiKey}{ts}Edit Api Key{/ts}{else}{ts}Add Api Key{/ts}{/if}</span></a>
             </div>
 
             {else}
-            <div>You are NOT authorized to display this API Key.</div>
-            {/if}   
-                
+            <div>{ts}You are NOT authorized to display this API Key.{/ts}</div>
+            {/if}
+
         </div>
     </fieldset>
 </div>


### PR DESCRIPTION
Some general updates to civix generated files, form markup, translated strings, and most importantly, switches the long-deprecated and soon-to-be-removed `hook_civicrm_tabs()` with the newer `hook_civicrm_tabset()`